### PR TITLE
Timing Bug Fix

### DIFF
--- a/build/player/lottie.js
+++ b/build/player/lottie.js
@@ -2054,6 +2054,7 @@
       this._idle = true;
       this.trigger('_idle');
       this.audioController.pause();
+      this.currentTime = 0;
     }
   };
 


### PR DESCRIPTION
Reset `currentTime` when animation is paused. This fixes an issue where the `AnimationItem` would skip ahead in an animation when playing from pause. The `currentTime` would be whatever it was last set to when paused in `advanceTime`, and the subsequent call to `advanceTime` after playing would result in a large delta time.

I tested this by editing the copy of the code in my node_modules folder and running awkword, where I was seeing the issue. I've also tested sketch heads and letter league briefly to see if there are any glaring issues. Everything looks ok to me.