### PR TITLE
Timing fix

### DIFF
--- a/build/player/lottie.js
+++ b/build/player/lottie.js
@@ -2035,6 +2035,7 @@
       this.isPaused = false;
       this.trigger('_pause');
       this.audioController.resume();
+      this.currentTime = 0;
 
       if (this._idle) {
         this._idle = false;


### PR DESCRIPTION
Fix for `currentTime` being incorrect when playing after autoplay is false. When autoplay is false does not start playing after loading, but `currentTime` is set and then not updated. When playing starts there is an initial jump because time time delta in `advanceTime` becomes very large. Resetting this to 0 results in the code using a fallback time where is ends up being 1 animation frame. I made a [similar change](https://github.com/discordgames/lottie-web/pull/1) recently to deal with the same issue exhibiting itself in the lottie state machine code. I figured doing it in pause would be sufficient for all cases, but I guess not.